### PR TITLE
fix(ci): pin tflint version in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,10 @@ permissions: write-all
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  # Pin tflint: the composite action's `latest` path scrapes the GitHub API with a
+  # greedy grep that breaks on the compact JSON responses GitHub sometimes returns
+  # (curl: (3) nested brace). A pinned version uses the deterministic download path.
+  TFLINT_VERSION: v0.63.1
 
 jobs:
   collectInputs:
@@ -57,6 +61,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@462243b714d762cbcac6732098e9fdb4ab236cb7 # v1.14.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: "terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*"
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
@@ -65,6 +70,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@462243b714d762cbcac6732098e9fdb4ab236cb7 # v1.14.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: "terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)"
 
   preCommitMaxVersion:
@@ -92,5 +98,6 @@ jobs:
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           install-hcledit: true
           hcledit-version: 0.2.6


### PR DESCRIPTION
## Problem

Both open PRs (and `main`) fail the **Pre-Commit** workflow on `Max TF pre-commit` (and intermittently `Min TF pre-commit`) with:

```
curl: (3) nested brace in URL position 407
##[error]Process completed with exit code 3.
```

## Root cause

The pinned `clowdhaus/terraform-composite-actions/pre-commit` action installs tflint via its `latest` branch:

```sh
curl ... "$(curl -s https://api.github.com/.../releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip
```

The `.+?` is not lazy in grep ERE, so on the compact single-line JSON the GitHub API intermittently returns, the match spans through the `{?name,label}` `upload_url` and hands curl a malformed URL. This is why failures are intermittent across jobs/runs.

## Fix

Pin `tflint-version` (`v0.63.1`) on all three `pre-commit` action invocations. A pinned version routes to the deterministic `releases/download/<version>/...` path and skips the broken API scrape. Verified the asset resolves (HTTP 200).

No Terraform code changes.